### PR TITLE
Leightweight Implementation of String Templates 

### DIFF
--- a/logo.java
+++ b/logo.java
@@ -1,4 +1,5 @@
 Clerk.markdown(
+    Text.fillOut(
 """
 # Turtle-Programmierung
 
@@ -35,15 +36,11 @@ Mit `new Turtle(300,300)` wird eine neue Schildkröte mittig auf eine Zeichenfl�
 Die folgende Logo-Anwendung demonstriert, wie man mittels Methoden schrittweise graphische Einheiten erstellen und zusammensetzen kann.
 
 ```java
-"""
-+
-Text.cutOut("./logo.java", "// myFirstTurtle") + "\n"
-+
-"""
+${0}
 ```
 
 Das Ergebnis sieht dann so aus: ein Quadrat aus Pfeilen, wobei absichtlich kleine Zwischenräume gelassen wurden, mit Angaben der Pfeilausrichtung.
-""");
+""", Text.cutOut("./logo.java", "// myFirstTurtle")));
 
 // myFirstTurtle
 Turtle myFirstTurtle = new Turtle(300, 300);
@@ -72,6 +69,7 @@ myFirstTurtle = write(myFirstTurtle, "North").right(90);
 // myFirstTurtle
 
 Clerk.markdown(
+    Text.fillOut(
 """
 ## Beispiel 2: Umsetzung eines Logo-Programms in Java
 
@@ -96,24 +94,17 @@ tree 150
 Die Java-Methode `tree` bildet das obige Logo-Programm nach; lediglich aus praktischen Überlegungen lasse ich den Rekursionsabbruch etwas früher greifen.
 
 ```java
-"""
-+
-Text.cutOut("./logo.java", "// turtle tree") + "\n"
-+
-"""
+${turtle_tree}
 ```
 
 Der Aufruf der Methode `tree` erzeugt etwas, was einem "Baum" ähnelt.
 
 ```java
-"""
-+
-Text.cutOut("./logo.java", "// tree") + "\n"
-+
-"""
+${tree}
 ```
 
-""");
+""", Map.of("turtle_tree", Text.cutOut("./logo.java", "// turtle tree"),
+            "tree", Text.cutOut("./logo.java", "// tree"))));
 
 // turtle tree
 Turtle turtle = new Turtle().left(90);
@@ -143,19 +134,17 @@ void tree(Turtle turtle, double size) {
 tree(turtle, 150);
 // tree
 
-Clerk.markdown("""
+Clerk.markdown(
+    Text.fillOut(
+"""
 ## Beispiel 3: Es kommt Farbe ins Spiel
 
 Mit Farbe wird die Welt bunter und interessanter, und die Strichstärke kann man ebenfalls für Effekte einsetzen. Im nachfolgenden Beispiel verblasst die Farbe zunehmend und die Strichstärke lässt allmählich nach.
 
 ```java
-"""
-+
-Text.cutOut("./logo.java", "// triangles") + "\n"
-+
-"""
+${0}
 ```
-""");
+""", Text.cutOut("./logo.java", "// triangles")));
 
 // triangles
 Turtle turtle = new Turtle(300,350);
@@ -176,23 +165,20 @@ void drawing(Turtle turtle, double size) {
 drawing(turtle, 100);
 // triangles
 
-Clerk.markdown("""
+Clerk.markdown(Text.fillOut(
+"""
 ## Beispiel 4: Interaktivität mit Slider (Preview-Feature, _unstable_)
 
 Es ist auch möglich, eine Turtle-Grafik mit einer Slider-View zu koppeln – und es entsteht eine interaktive Anwendung.
 
 ```java
-"""
-+
-Text.cutOut("./logo.java", "// interactivity") + "\n"
-+
-"""
+${0}
 ```
 
 Das macht noch mehr Spaß! Die Zeichnungen werden auf Seiten des Java-Programms mit jeder Änderung am Slider neu erzeugt.
 
 > Nutzt man die Entwicklertools im Chrome-Browser, um die internen Abläufe zu verfolgen, treten beim "Sliden" sofort `onerror`-Events auf. Der Browser erholt sich zwar davon, aber der Interaktionseffekt ist dahin. Ohne Entwicklertools läuft auf einem MacBook Air mit M1-Prozessor meist alles flüssig und unproblematisch. Allerdings gibt es auch hier gelegentlich Aussetzer. Es scheint nötig zu sein, während der Abarbeitung des `input`-Events vom Slider weitere Folgeevents zu unterbinden. Wie gesagt, ein Preview-Feature, wo es noch hakt.
-""");
+""", Text.cutOut("./logo.java", "// interactivity")));
 
 // interactivity
 turtle = new Turtle(300, 350);

--- a/skills/Text/Text.java
+++ b/skills/Text/Text.java
@@ -5,6 +5,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 class Text { // Class with static methods for file operations
     static void write(String fileName, String text) {
@@ -62,5 +67,36 @@ class Text { // Class with static methods for file operations
         return text.replaceAll("&", "&amp;")
             .replaceAll("<", "&lt;")
             .replaceAll(">", "&gt;");
+    }
+
+    // Method `fillOut` emulates String interpolation, since String Templates
+    // have been removed in Java 23 (they were a preview feature in Java 21 and 22).
+
+    static String fillOut(Map<String, Object> replacements, String template) {
+        Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}"); // `${<key>}`
+        Matcher matcher = pattern.matcher(template);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            if (!replacements.containsKey(key))
+                System.err.println("WARNING: key +`" + key + "` not found in template:\n" + template);
+            Object replacement = replacements.getOrDefault(key, ""); 
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement.toString()));
+        }
+        matcher.appendTail(result);
+
+        return result.toString();
+    }
+
+    static String fillOut(String template, Map<String, Object> replacements) {
+        return fillOut(replacements, template);
+    }
+
+    static String fillOut(String template, Object... replacements) {
+        Map<String, Object> m = new HashMap<>();
+        IntStream.range(0, replacements.length)
+            .forEach(i -> m.put(Integer.toString(i), replacements[i]));
+        return fillOut(m, template);
     }
 }

--- a/skills/Text/TextTest.java
+++ b/skills/Text/TextTest.java
@@ -1,0 +1,13 @@
+assert Text.fillOut(
+    "Das Ergebnis ist ${#1} oder ${#2}.",
+    Map.of("#1", 2 + 3, "#2", 42)).equals(
+    "Das Ergebnis ist 5 oder 42.");
+
+assert Text.fillOut(
+    Map.of("#1", 2 + 3, "#2", 42),
+    "Das Ergebnis ist ${#1} oder ${#2}.").equals(
+    "Das Ergebnis ist 5 oder 42.");
+
+assert Text.fillOut(
+    "Das Ergebnis ist ${0} oder ${1}.", 2 + 3, 42).equals(
+    "Das Ergebnis ist 5 oder 42.");

--- a/views/Markdown/CodeDokuMitMarkdown.java
+++ b/views/Markdown/CodeDokuMitMarkdown.java
@@ -1,4 +1,3 @@
-
 Clerk.markdown("""
 # Die Code-Dokumentation mit Markdown
 
@@ -6,9 +5,11 @@ Für die Code-Dokumentation mit Markdown sind Textblöcke und der Text-Skill ent
 
 * Mit Textblöcken lassen sich String-Literale als Textblöcke über mehrere Zeilen hinweg angeben. Ein solcher Textblock beginnt und endet mit drei Anführungszeichen `\"""`.
 
-* Das LVP bringt einen Text-Skill mit, der hauptsächlich dafür da ist, um Text aus einer Datei auszuschneiden. Der Bereich, der ausgeschnitten werden soll, wird durch Textmarken (Labels) ausgewiesen.
+* Das LVP bringt einen Text-Skill mit, der hauptsächlich dafür da ist,
+  - um Text aus einer Datei auszuschneiden (Methode `cutOut`); der Bereich, der ausgeschnitten werden soll, wird durch Textmarken (Labels) ausgewiesen.
+  - um Text mit Aufüllfeldern zu versehen (Methode `fillOut`), in die Ergebnisse aus Auswertungen als Zeichenkette eingefügt werden.
 
-> In den Java-Versionen 21 und 22 gab es [String-Templates](https://docs.oracle.com/en/java/javase/22/language/string-templates.html) als Preview-Feature. Damit ließen sich sehr elegant die Auswertungen von Ausdrücken mitten in einen String einfügen. Leider sind die String-Templates mit Java 23 wieder entfernt worden -- ein einmaliger Vorgang für Preview-Features in der Historie von Java. Man kann nur hoffen, dass eine neue Form der String-Templates nicht lange auf sich warten lässt.
+> In den Java-Versionen 21 und 22 gab es [String-Templates](https://docs.oracle.com/en/java/javase/22/language/string-templates.html) als Preview-Feature. Damit ließen sich sehr elegant die Auswertungen von Ausdrücken mitten in einen String einfügen. Das wird in anderen Programmiersprachen auch als String-Interpolation bezeichnet. Leider sind die String-Templates mit Java 23 wieder entfernt worden -- ein einmaliger Vorgang für Preview-Features in der Historie von Java. Als leichtgewichtigen Ersatz gibt es deshalb im Text-Skill die statische Methode `fillOut`.
 
 """);
 
@@ -24,42 +25,55 @@ assert factorial(2) == 2 && factorial(3) == 6;
 assert factorial(4) == 24 && factorial(5) == 120;
 // Ende Fakultätsfunktion
 
-// STR-Beispiel
+// Beispiel
 int num;
 String s = "Die Fakultät von " + (num = 6) + " ist " + factorial(num) + ".";
-// STR-Beispiel
+// Beispiel
 
 
-Clerk.markdown("""
+Clerk.markdown(Text.fillOut("""
 ## Dynamische Inhalte in Zeichenketten einbetten
 
-Ohne String-Templates muss man auf bewährte Weise Zeichenketten mit dem `+`-Operator verketten (konkatenieren). Wenn Inhalte in einer Zeichenkette dynamisch berechnet und eingefügt werden sollen, kann man das beispielsweise wie folgt machen:
+Wenn Inhalte in einer Zeichenkette dynamisch berechnet und eingefügt werden sollen, kann man das beispielsweise wie folgt machen:
 
 ```
-"""
-+
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// STR-Beispiel") + "\n"
-+
-"""
+${Beispiel}
 ```
 
 Das Ergebnis der Zeichenkette `s` ist
 
 ```
-"""
-+
-s + "\n"
-+
-"""
+${Resultat}
 ```
 
-Das sieht dann im Markdown-Fließtext so aus: \s""" + s + "\n" +
-"""
+Das sieht dann, wenn man die Zeichenkette im Markdown einfügt (mit `Text.fillOut`), so aus: ${Resultat}
 
-Diese Technik der Einbettung von dynamischen Inhalten in eine Zeichenkette lässt sich ausreizen mit der Text-Skill. Damit kann der Java-Quelltext sich zur Laufzeit selbst ausschneiden zur Einbettung in Markdown! Das ist der Schlüssel zu sich selbst dokumentierenden Dokumenten.
-""");
+Diese Technik der Einbettung von dynamischen Inhalten in eine Zeichenkette lässt sich ausreizen mit der Text-Skill. Damit kann der Java-Quelltext sich zur Laufzeit selbst ausschneiden zur Einbettung in Markdown! Das ist der Schlüssel zu sich selbst dokumentierendem Programmcode.
+""", Map.of("Beispiel", Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// Beispiel"),
+            "Resultat", s)));
 
-Clerk.markdown("""
+Clerk.markdown(Text.fillOut(Map.of(
+"LabelCff",
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelCff"),
+"ResultLabelCff",
+// LabelCff
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", false, false, "// LabelC")
+// LabelCff
+, "LabelCft",
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelCft"),
+"ResultLabelCft",
+// LabelCft
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", false, true, "// LabelC")
+// LabelCft
+, "LabelAB",
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelAB"),
+"ResultLabelAB",
+// LabelAB
+Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelA", "// LabelB")
+// LabelAB
+, "TextCutOut",
+Text.cutOut("skills/Text/Text.java", "// core method", "// end")
+), """
 ## Texte ausschneiden mit `Text.cut`
 
 Mit dem Skill `Text` kann Text aus einer Datei ausgeschnitten werden. Der Methodenkopf von `cutOut` erwartet einen Dateinamen, zwei boolsche Werte und eine beliebige Anzahl an Labels.
@@ -89,23 +103,13 @@ Textstelle, umschlossen von einem LabelC
 Der folgende Aufruf
 
 ```
-"""
-+
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelCff") + "\n"
-+
-"""
+${LabelCff}
 ```
 
 liefert als Zeichenkette diesen Auszug (Snippet) aus der Datei zurück:
 
 ```
-"""
-+
-// LabelCff
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", false, false, "// LabelC")
-// LabelCff
-+ "\n" + 
-"""
+${ResultLabelCff}
 ```
 
 > Der Witz an diesem Beispiel ist das, was man hier nicht sieht, aber wichtig für die Idee einer eingebetteten, dynamischen Dokumentation ist: Der obige Aufruf ist tatsächlich ein Snippet von dem Code, der das resultierende Snippet erzeugt. Das klingt ein wenig seltsam, aber das ist genau der Kunstgriff, der garantiert, dass der Aufruf wirklich der ist, der das Ergebnis produziert. Wenn Sie einen Blick in die Java-Datei werfen, die diese View im Browser erzeugt hat, werden Sie das vermutlich verstehen und nachvollziehen können. Vergleichen Sie den Java-Quellcode mit dem Text im Browser.
@@ -113,45 +117,25 @@ Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", false, false, "// LabelC"
 Setzt man einen der boolschen Werte auf `true`, wird das entsprechende Label mit übernommen.
 
 ```
-"""
-+
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelCft") + "\n"
-+
-"""
+${LabelCft}
 ```
 
 Das Ergebnis sieht so aus:
 
 ```
-"""
-+
-// LabelCft
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", false, true, "// LabelC")
-// LabelCft
-+ "\n" +
-"""
+${ResultLabelCft}
 ```
 
 Sind mehrere Stellen mit dem gleichen Label belegt, kann man diese Bereiche ausschneiden. Wenn die boolschen Werte beide `false` sind, kann man den Aufruf verkürzen.
 
 ```
-"""
-+
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelAB") + "\n"
-+
-"""
+${LabelAB}
 ```
 
 Zunächst wird die erste Textstelle zwischen `LabelA` und `LabelB` ausgeschnitten, dann die zweite.
 
 ```
-"""
-+
-// LabelAB
-Text.cutOut("views/Markdown/CodeDokuMitMarkdown.java", "// LabelA", "// LabelB")
-// LabelAB
-+ "\n" +
-"""
+${ResultLabelAB}
 ```
 
 ### Der Algorithmus zu `Text.cutOut`
@@ -166,10 +150,6 @@ Der Algorithmus zu `Text.cutOut(...)`, um einen Bereich aus einer Textdatei zu s
 Als Java-Methode:
 
 ```java
-"""
-+
-Text.cutOut("skills/Text/Text.java", "// core method", "// end") + "\n"
-+
-"""
+${TextCutOut}
 ```
-""");
+"""));


### PR DESCRIPTION
Nachdem die String Templates mit Java 23 wieder entfernt wurden (sie waren ein Preview Feature in Java 21 und 22) musste ein Ersatz her. Denn sie haben die Programmierung deutlich übersichtlicher und einfacher gemacht.